### PR TITLE
Set ezpublish-legacy-dir default to ezpublish_legacy

### DIFF
--- a/src/eZ/Publish/Composer/LegacyInstaller.php
+++ b/src/eZ/Publish/Composer/LegacyInstaller.php
@@ -30,7 +30,7 @@ abstract class LegacyInstaller extends LibraryInstaller
     {
         parent::__construct( $io, $composer, $type );
         $options = $composer->getPackage()->getExtra();
-        $this->ezpublishLegacyDir = isset( $options['ezpublish-legacy-dir'] ) ? rtrim( $options['ezpublish-legacy-dir'], '/' ) : '.';
+        $this->ezpublishLegacyDir = isset( $options['ezpublish-legacy-dir'] ) ? rtrim( $options['ezpublish-legacy-dir'], '/' ) : 'ezpublish_legacy';
     }
 
     public function getInstallPath( PackageInterface $package )


### PR DESCRIPTION
The ezplatform repository doesn't have a ezpublish-legacy-dir option by default.
So it would be better to set the default here to ezpublish_legacy.