### PR TITLE
Update LegacyKernelInstaller for installBinaries changes in composer …

### DIFF
--- a/src/eZ/Publish/Composer/LegacyKernelInstaller.php
+++ b/src/eZ/Publish/Composer/LegacyKernelInstaller.php
@@ -78,7 +78,7 @@ class LegacyKernelInstaller extends LegacyInstaller
         $fileSystem->copyThenRemove( $this->ezpublishLegacyDir, $actualLegacyDir );
 
         // if parent::install installed binaries, then the resulting shell/bat stubs will not work. We have to redo them
-        if(method_exists($this,'removeBinaries'))
+        if( method_exists($this,'removeBinaries') )
         {
             $this->removeBinaries( $package );
         }
@@ -86,8 +86,16 @@ class LegacyKernelInstaller extends LegacyInstaller
         {
             $this->binaryInstaller->removeBinaries( $package );
         }
+
         $this->ezpublishLegacyDir = $actualLegacyDir;
-        $this->installBinaries( $package );
+        if( method_exists($this,'installBinaries') )
+        {
+            $this->installBinaries( $package );
+        }
+        else
+        {
+            $this->binaryInstaller->installBinaries( $package );
+        }
     }
 
     /**

--- a/src/eZ/Publish/Composer/LegacyKernelInstaller.php
+++ b/src/eZ/Publish/Composer/LegacyKernelInstaller.php
@@ -94,7 +94,7 @@ class LegacyKernelInstaller extends LegacyInstaller
         }
         else
         {
-            $this->binaryInstaller->installBinaries( $package );
+            $this->binaryInstaller->installBinaries( $package, $this->getInstallPath( $package ) );
         }
     }
 


### PR DESCRIPTION
…1.0.0-beta2

#15 wasn't complete, seems neither patch contributor or commenters tested or validated that patch was sane.


*So tested on 5.3 install and seems to work, please test as well, just set this package temporarily to `dev-installBinariespatch` in composer.json and run update a few times.*