### PR TITLE
Support promises in Composer 2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,7 @@
         "class": "eZ\\Publish\\Composer\\InstallerPlugin"
     },
     "require": {
+        "php": "^5.4 || ^7.0",
         "composer-plugin-api": "^1.0 || ^2.0"
     }
 }


### PR DESCRIPTION
Package installers in Composer 2 may return promises in `install/updateCode` methods, so we support them here.